### PR TITLE
Change opacity to use decimal values instead of percents

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -110,7 +110,7 @@ a:visited {
   border-radius: 8%;
   text-decoration: line-through;
   cursor: pointer;
-  opacity: 80%;
+  opacity: 0.8;
 }
 
 /* Add View Specific Styling */
@@ -129,7 +129,7 @@ a:visited {
   display: inline-block;
   padding: 10px 20px;
   margin: 1vh;
-  opacity: 90%;
+  opacity: 0.9;
   font-size: 0.9rem;
   border: 2px solid #000;
 }
@@ -137,7 +137,7 @@ a:visited {
 .daysButtons input[type='radio']:focus + label,
 .daysButtons input[type='radio']:checked + label,
 .daysButtons label:hover {
-  opacity: 100%;
+  opacity: 1;
   box-shadow: 2px 2px 3px #000;
   font-size: 1rem;
   cursor: pointer;


### PR DESCRIPTION
It looks like the one CSS rule we had that used a decimal value (the error that appears when we try to add a duplicate item) retained it's opacity. I think it's worth trying to change all of our opacity rules to using decimal values and see if that works on our live site. Thoughts? 