### PR TITLE
Mz ce view purchase details

### DIFF
--- a/cypress/integration/fetch_items.js
+++ b/cypress/integration/fetch_items.js
@@ -42,6 +42,12 @@ describe("Show list of items", function() {
       cy.get('.purchasedItem');
       expect(cy.contains('Purchased Item'));
     });
+
+    it('View more link goes to item details page', function() {
+      cy.visit('/list');
+      cy.get('#banana > .viewMore').invoke('show').click();
+      cy.url().should('eq', Cypress.config().baseUrl + '/banana')
+    });
   });
 
   afterEach(function() {
@@ -59,9 +65,7 @@ describe("Show list of items", function() {
       }
 
       let newTestData = calculateNewPurchaseValues(testData, today);
-      console.log('DATE OF PURCHASE: ',testData.dateOfPurchase)
-      console.log(newTestData);
-      expect(newTestData.numberOfDays).to.eq(26);
+      expect(newTestData.numberOfDays).to.eq(28);
       expect(newTestData.numberOfPurchases).to.eq(4);
     })
   })

--- a/cypress/integration/fetch_items.js
+++ b/cypress/integration/fetch_items.js
@@ -65,7 +65,7 @@ describe("Show list of items", function() {
       }
 
       let newTestData = calculateNewPurchaseValues(testData, today);
-      expect(newTestData.numberOfDays).to.eq(28);
+      expect(newTestData.numberOfDays).to.eq(19.6);
       expect(newTestData.numberOfPurchases).to.eq(4);
     })
   })

--- a/cypress/integration/item_details.js
+++ b/cypress/integration/item_details.js
@@ -6,7 +6,7 @@ describe('Item details view', function() {
   });
 	
 	it('Shows current date as last purchase date when purchased today', function() {
-		let todayString = new Date().toDateString();
+		const todayString = new Date().toDateString();
 
 		cy.visit('/list');
 		cy.get('#banana').click();

--- a/cypress/integration/item_details.js
+++ b/cypress/integration/item_details.js
@@ -1,0 +1,14 @@
+describe('Item details view', function() {
+  beforeEach(function() {
+		window.localStorage.setItem('uniqueToken', 'token1234')
+  });
+	
+	it('Shows current date as last purchase date when purchased today', function() {
+		let todayString = new Date().toDateString();
+
+		cy.visit('/list');
+		cy.get('#banana').click();
+		cy.visit('/banana');
+		cy.contains(todayString);
+	});
+});

--- a/cypress/integration/item_details.js
+++ b/cypress/integration/item_details.js
@@ -1,6 +1,8 @@
 describe('Item details view', function() {
   beforeEach(function() {
 		window.localStorage.setItem('uniqueToken', 'token1234')
+		const testDate = new Date('2019-01-01');
+		cy.addItem('token1234', 'banana', testDate);
   });
 	
 	it('Shows current date as last purchase date when purchased today', function() {
@@ -8,7 +10,12 @@ describe('Item details view', function() {
 
 		cy.visit('/list');
 		cy.get('#banana').click();
+		cy.wait(2000);
 		cy.visit('/banana');
 		cy.contains(todayString);
 	});
+
+	afterEach(function() {
+		cy.deleteItem('token1234', 'banana');
+	})
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,21 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+import { db } from '../../src/lib/firebase';
+
+Cypress.Commands.add("addItem", (token, itemID, dateOfPurchase) => {
+	db.collection('lists').doc(token).set({ items: '' });
+	db.collection('lists').doc(token).collection('items').doc(itemID)
+		.set({
+			id: itemID,
+			name: itemID,
+			numberOfDays: 14,
+			dateOfPurchase: dateOfPurchase,
+			numberOfPurchases: 1,
+	})
+});
+
+Cypress.Commands.add("deleteItem", (token, itemID) => { 
+	db.collection("lists").doc(token).collection('items').doc(itemID).delete();
+ })

--- a/src/App.css
+++ b/src/App.css
@@ -82,6 +82,10 @@ a:visited {
 
 /* List View Specific Styling */
 
+.fetchItems {
+  width: 80vw;
+}
+
 .delete-button {
   position: absolute;
   top: 5vh;
@@ -95,11 +99,13 @@ a:visited {
 
 .listItem {
   list-style-type: none;
-  margin: 5vh;
+  width: fit-content;
+  margin: 5vh auto;
+  display: flex;
 }
 
 .listItem:hover .viewMore {
-  display: inline;
+  display: inline-block;
 }
 
 .nonPurchasedItem {
@@ -119,12 +125,13 @@ a:visited {
 }
 
 .viewMore {
-  margin-left: 20px;
   background-color: #fff;
   border-radius: 8%;
   padding: 10px;
   display: none;
   color: #000;
+  height: fit-content;
+  margin: auto 0 auto 20px;
 }
 
 /* Add View Specific Styling */

--- a/src/App.css
+++ b/src/App.css
@@ -256,3 +256,8 @@ a:visited {
     top: -10%;
   }
 }
+
+/* Item Detail Styling */
+.itemDetails {
+  list-style: none;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -93,24 +93,33 @@ a:visited {
   font-size: 1.1rem;
 }
 
-.nonPurchasedItem {
+.listItem {
   list-style-type: none;
+  margin: 5vh;
+  margin-left: 6vw;
+}
+
+.nonPurchasedItem {
   padding: 10px;
-  margin: 10px;
   background-color: #ff165d;
   border-radius: 8%;
 }
 
 .nonPurchasedItem:hover,
 .purchasedItem {
-  list-style-type: none;
   padding: 10px;
-  margin: 10px;
   background-color: #ff165d;
   border-radius: 8%;
   text-decoration: line-through;
   cursor: pointer;
-  opacity: 80%;
+  opacity: 0.8;
+}
+
+.viewMore {
+  margin-left: 20px;
+  background-color: #ffd800;
+  border-radius: 8%;
+  padding: 5px;
 }
 
 /* Add View Specific Styling */
@@ -129,7 +138,7 @@ a:visited {
   display: inline-block;
   padding: 10px 20px;
   margin: 1vh;
-  opacity: 90%;
+  opacity: 0.9;
   font-size: 0.9rem;
   border: 2px solid #000;
 }
@@ -137,7 +146,7 @@ a:visited {
 .daysButtons input[type='radio']:focus + label,
 .daysButtons input[type='radio']:checked + label,
 .daysButtons label:hover {
-  opacity: 100%;
+  opacity: 1;
   box-shadow: 2px 2px 3px #000;
   font-size: 1rem;
   cursor: pointer;

--- a/src/App.css
+++ b/src/App.css
@@ -96,7 +96,10 @@ a:visited {
 .listItem {
   list-style-type: none;
   margin: 5vh;
-  margin-left: 6vw;
+}
+
+.listItem:hover .viewMore {
+  display: inline;
 }
 
 .nonPurchasedItem {
@@ -117,9 +120,11 @@ a:visited {
 
 .viewMore {
   margin-left: 20px;
-  background-color: #ffd800;
+  background-color: #fff;
   border-radius: 8%;
-  padding: 5px;
+  padding: 10px;
+  display: none;
+  color: #000;
 }
 
 /* Add View Specific Styling */

--- a/src/calculations.js
+++ b/src/calculations.js
@@ -20,8 +20,7 @@ const calculateEstimate = (lastEstimate, latestInterval, numberOfPurchases) => {
 };
 
 // Uses past data and today's date to calculate new numberOfDays, nextPurchaseDate, and numberOfPurchases
-const calculateNewPurchaseValues = data => {
-  let today = new Date();
+const calculateNewPurchaseValues = (data, today) => {
   let now = dayjs(today);
 
   let lastPurchaseDate =

--- a/src/component/FetchItems.js
+++ b/src/component/FetchItems.js
@@ -86,18 +86,18 @@ const FetchItems = ({ token, setToken, firestore }) => {
             );
           } else {
             return (
-              <div>
+              <div className="fetchItems">
                 <h2>Items</h2>
                 <ul>
                   {data.map(item => (
                     <li id={item.id} key={item.id} className="listItem">
-                      <span
+                      <div
                         className={calculateIfPurchased(item)}
                         onClick={handlePurchase}
                         id={item.id}
                       >
                         {item.name}
-                      </span>
+                      </div>
                       <Link className="viewMore" to={'/' + item.id}>
                         >>>
                       </Link>

--- a/src/component/FetchItems.js
+++ b/src/component/FetchItems.js
@@ -35,7 +35,7 @@ const FetchItems = ({ token, setToken, firestore }) => {
       .doc(itemId)
       .get()
       .then(doc => {
-        return calculateNewPurchaseValues(doc.data());
+        return calculateNewPurchaseValues(doc.data(), now);
       })
       .then(updateDatabase);
   };

--- a/src/component/FetchItems.js
+++ b/src/component/FetchItems.js
@@ -8,11 +8,12 @@ import dayjs from 'dayjs';
 
 const FetchItems = ({ token, setToken, firestore }) => {
   const [empty, setEmpty] = useState(true);
+  let itemsDocRef;
 
   if (!token) {
     return <Redirect to="" />;
   } else {
-    var itemsDocRef = firestore // use var for function scoping
+    itemsDocRef = firestore
       .collection('lists')
       .doc(token)
       .collection('items');

--- a/src/component/FetchItems.js
+++ b/src/component/FetchItems.js
@@ -90,18 +90,17 @@ const FetchItems = ({ token, setToken, firestore }) => {
                 <h2>Items</h2>
                 <ul>
                   {data.map(item => (
-                    <li
-                      id={item.id}
-                      key={item.id}
-                      className={calculateIfPurchased(item)}
-                    >
-                      <div
-                        className={item.name}
+                    <li id={item.id} key={item.id} className="listItem">
+                      <span
+                        className={calculateIfPurchased(item)}
                         onClick={handlePurchase}
                         id={item.id}
                       >
                         {item.name}
-                      </div>
+                      </span>
+                      <Link className="viewMore" to={'/' + item.id}>
+                        >>>
+                      </Link>
                     </li>
                   ))}
                 </ul>

--- a/src/component/ItemDetails.js
+++ b/src/component/ItemDetails.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ItemDetails = () => {
+  return <div></div>;
+};
+
+export default ItemDetails;

--- a/src/component/ItemDetails.js
+++ b/src/component/ItemDetails.js
@@ -12,30 +12,30 @@ const ItemDetails = ({ token, setToken }) => {
     <FirestoreCollection
       path={concatPath}
       render={({ isLoading, data }) => {
-        // Finds specific item where the url param :itemId is equal to the item ID in the list.
+        // Finds specific item mentioned in url param :itemID so we can pull out just that item's details.
         const item = data.find(x => x.id === itemId);
 
         if (isLoading) {
           return <div>Still Loading...</div>;
-        } else {
-          // Below lines calculate next purchase date using dayjs 'add' function.
-          const lastPurchaseDate = item.dateOfPurchase.toDate();
-          const nextPurchaseDate = dayjs(lastPurchaseDate)
-            .add(item.numberOfDays.toString(), 'day')
-            .toDate();
-
-          return (
-            <main>
-              <BackButton />
-              <h1>{item.name}</h1>
-              <ul className="itemDetails">
-                <li>Last purchase: {lastPurchaseDate.toDateString()}</li>
-                <li>Next purchase: {nextPurchaseDate.toDateString()}</li>
-                <li>Number of purchases: {item.numberOfPurchases}</li>
-              </ul>
-            </main>
-          );
         }
+
+        // Below lines calculate next purchase date using dayjs 'add' function.
+        const lastPurchaseDate = item.dateOfPurchase.toDate();
+        const nextPurchaseDate = dayjs(lastPurchaseDate)
+          .add(item.numberOfDays.toString(), 'day')
+          .toDate();
+
+        return (
+          <main>
+            <BackButton />
+            <h1>{item.name}</h1>
+            <ul className="itemDetails">
+              <li>Last purchase: {lastPurchaseDate.toDateString()}</li>
+              <li>Next purchase: {nextPurchaseDate.toDateString()}</li>
+              <li>Number of purchases: {item.numberOfPurchases}</li>
+            </ul>
+          </main>
+        );
       }}
     />
   );

--- a/src/component/ItemDetails.js
+++ b/src/component/ItemDetails.js
@@ -1,7 +1,31 @@
 import React from 'react';
+import { FirestoreCollection, withFirestore } from 'react-firestore';
 
-const ItemDetails = () => {
-  return <div></div>;
+const ItemDetails = props => {
+  const uniqueToken = localStorage.getItem('uniqueToken');
+  const concatPath = `/lists/${uniqueToken}/items`;
+
+  return (
+    <FirestoreCollection
+      /* //name of collection you want to collect, with filter you can narrow this
+      down to specific document  */
+      path={concatPath}
+      render={({ isLoading, data }) => {
+        // Renders according to whether or not the list is empty
+        const item = data.find(x => x.id === 'banana');
+        if (isLoading) {
+          return <div>Still Loading...</div>;
+        } else {
+          return (
+            <main>
+              <h1>{item.name}</h1>
+              <p>{item.dateOfPurchase}</p>
+            </main>
+          );
+        }
+      }}
+    />
+  );
 };
 
-export default ItemDetails;
+export default withFirestore(ItemDetails);

--- a/src/component/ItemDetails.js
+++ b/src/component/ItemDetails.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FirestoreCollection, withFirestore } from 'react-firestore';
+import dayjs from 'dayjs';
 
 const ItemDetails = props => {
   const uniqueToken = localStorage.getItem('uniqueToken');
@@ -13,13 +14,20 @@ const ItemDetails = props => {
       render={({ isLoading, data }) => {
         // Renders according to whether or not the list is empty
         const item = data.find(x => x.id === 'banana');
+
         if (isLoading) {
           return <div>Still Loading...</div>;
         } else {
+          const lastPurchaseDate = item.dateOfPurchase.toDate();
+          const nextPurchaseDate = dayjs(lastPurchaseDate)
+            .add(item.numberOfDays.toString(), 'day')
+            .toDate();
+
           return (
             <main>
               <h1>{item.name}</h1>
-              <p>{item.dateOfPurchase}</p>
+              <p>{lastPurchaseDate.toDateString()}</p>
+              <p>{nextPurchaseDate.toDateString()}</p>
             </main>
           );
         }

--- a/src/component/ItemDetails.js
+++ b/src/component/ItemDetails.js
@@ -4,16 +4,15 @@ import dayjs from 'dayjs';
 import { useParams } from 'react-router-dom';
 import BackButton from './BackButton';
 
-const ItemDetails = () => {
+const ItemDetails = ({ token, setToken }) => {
   let { itemId } = useParams();
-  const uniqueToken = localStorage.getItem('uniqueToken');
-  const concatPath = `/lists/${uniqueToken}/items`;
+  const concatPath = `/lists/${token}/items`;
 
   return (
     <FirestoreCollection
       path={concatPath}
       render={({ isLoading, data }) => {
-        // Finds specific element where the url param :itemId is equal to the item ID in the list.
+        // Finds specific item where the url param :itemId is equal to the item ID in the list.
         const item = data.find(x => x.id === itemId);
 
         if (isLoading) {

--- a/src/component/ItemDetails.js
+++ b/src/component/ItemDetails.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { FirestoreCollection, withFirestore } from 'react-firestore';
 import dayjs from 'dayjs';
+import { useParams } from 'react-router-dom';
 
-const ItemDetails = props => {
+const ItemDetails = () => {
+  let { itemId } = useParams();
   const uniqueToken = localStorage.getItem('uniqueToken');
   const concatPath = `/lists/${uniqueToken}/items`;
 
@@ -13,7 +15,7 @@ const ItemDetails = props => {
       path={concatPath}
       render={({ isLoading, data }) => {
         // Renders according to whether or not the list is empty
-        const item = data.find(x => x.id === 'banana');
+        const item = data.find(x => x.id === itemId);
 
         if (isLoading) {
           return <div>Still Loading...</div>;

--- a/src/component/ItemDetails.js
+++ b/src/component/ItemDetails.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { FirestoreCollection, withFirestore } from 'react-firestore';
 import dayjs from 'dayjs';
 import { useParams } from 'react-router-dom';
+import BackButton from './BackButton';
 
 const ItemDetails = () => {
   let { itemId } = useParams();
@@ -27,10 +28,11 @@ const ItemDetails = () => {
 
           return (
             <main>
+              <BackButton />
               <h1>{item.name}</h1>
               <ul className="itemDetails">
-                <li>Last purchase date: {lastPurchaseDate.toDateString()}</li>
-                <li>Next purchase date: {nextPurchaseDate.toDateString()}</li>
+                <li>Last purchase: {lastPurchaseDate.toDateString()}</li>
+                <li>Next purchase: {nextPurchaseDate.toDateString()}</li>
                 <li>Number of purchases: {item.numberOfPurchases}</li>
               </ul>
             </main>

--- a/src/component/ItemDetails.js
+++ b/src/component/ItemDetails.js
@@ -26,7 +26,7 @@ const ItemDetails = props => {
           return (
             <main>
               <h1>{item.name}</h1>
-              <ul>
+              <ul className="itemDetails">
                 <li>Last purchase date: {lastPurchaseDate.toDateString()}</li>
                 <li>Next purchase date: {nextPurchaseDate.toDateString()}</li>
                 <li>Number of purchases: {item.numberOfPurchases}</li>

--- a/src/component/ItemDetails.js
+++ b/src/component/ItemDetails.js
@@ -11,16 +11,15 @@ const ItemDetails = () => {
 
   return (
     <FirestoreCollection
-      /* //name of collection you want to collect, with filter you can narrow this
-      down to specific document  */
       path={concatPath}
       render={({ isLoading, data }) => {
-        // Renders according to whether or not the list is empty
+        // Finds specific element where the url param :itemId is equal to the item ID in the list.
         const item = data.find(x => x.id === itemId);
 
         if (isLoading) {
           return <div>Still Loading...</div>;
         } else {
+          // Below lines calculate next purchase date using dayjs 'add' function.
           const lastPurchaseDate = item.dateOfPurchase.toDate();
           const nextPurchaseDate = dayjs(lastPurchaseDate)
             .add(item.numberOfDays.toString(), 'day')

--- a/src/component/ItemDetails.js
+++ b/src/component/ItemDetails.js
@@ -26,8 +26,11 @@ const ItemDetails = props => {
           return (
             <main>
               <h1>{item.name}</h1>
-              <p>{lastPurchaseDate.toDateString()}</p>
-              <p>{nextPurchaseDate.toDateString()}</p>
+              <ul>
+                <li>Last purchase date: {lastPurchaseDate.toDateString()}</li>
+                <li>Next purchase date: {nextPurchaseDate.toDateString()}</li>
+                <li>Number of purchases: {item.numberOfPurchases}</li>
+              </ul>
             </main>
           );
         }

--- a/src/component/Router.js
+++ b/src/component/Router.js
@@ -6,6 +6,7 @@ import FetchItems from './FetchItems';
 import AddItem from './AddItem';
 import JoinList from './JoinList';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import ItemDetails from './ItemDetails';
 
 function RouterComponent() {
   const [token, setToken] = useState(localStorage.getItem('uniqueToken'));
@@ -21,6 +22,9 @@ function RouterComponent() {
         </Route>
         <Route path="/join">
           <JoinList token={token} setToken={setToken} />
+        </Route>
+        <Route path="/:itemId">
+          <ItemDetails token={token} setToken={setToken} />
         </Route>
         <Route path="">
           {token === null ? (


### PR DESCRIPTION
- Added a new view, `ItemDetails`, that lists out the details of an individual item. 
- Used CSS to show/hide a view more button on hover. 
- Used react router dom's `useParams()` function and the colon syntax in the router to go to pages based off of specific item IDs. 

**AC:**
From the shopping list, user can tap to enter a detailed view of the item 

Detail view includes the following information: 
- Name of the item 
- Last purchased date 
- Estimated next purchase date 
- Number of times the item has been purchased

Accessibility for item details view is good! Though we worked in the fetch items page it made more sense to fix those accessibility issues in a separate PR after this week's AC's get merged. 

Let us know what you think!